### PR TITLE
Upgrade transformer package version to 4.40.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 altair<5 #need to pin altair version when using steamlit<1.23.0
 torch==1.11.0
 torchvision==0.12.0
-transformers==4.17.0
+transformers==4.40.2
 tensorboardX==2.5
 tensorboard==2.8.0
 sentencepiece==0.1.96


### PR DESCRIPTION
The Transformer Python package has a dependency on the tokenizer package, which was updated to version 1.19.0 on April 17, 2024, causing breaking changes. There are two options to resolve this issue:

1. Pin the tokenizer package to a specific version.
2. Update the TensorFlow package to the latest version, as it now specifies a minimum and maximum version range for tokenizer (Recommended).
## Testing
**Pre:** 
<img width="733" alt="Screenshot 2024-05-10 at 3 58 45 PM" src="https://github.com/cloudera/CML_AMP_Question_Answering/assets/19422305/bade20e5-01a0-4685-86b4-4e7c538af328">

**Post**:
<img width="919" alt="Screenshot 2024-05-10 at 4 33 13 PM" src="https://github.com/cloudera/CML_AMP_Question_Answering/assets/19422305/4b74f8ed-f089-448d-95c4-284732a8eb5c">

